### PR TITLE
Fix compile after change in hyprland header location in 0.38.0

### DIFF
--- a/src/Flash.cpp
+++ b/src/Flash.cpp
@@ -2,7 +2,7 @@
 #include "Globals.hpp"
 
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/Window.hpp>
+#include <hyprland/src/desktop/Window.hpp>
 #include <hyprland/src/managers/AnimationManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 

--- a/src/Shrink.cpp
+++ b/src/Shrink.cpp
@@ -2,7 +2,7 @@
 
 #include "Log.hpp"
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/Window.hpp>
+#include <hyprland/src/desktop/Window.hpp>
 #include <hyprland/src/managers/AnimationManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <hyprland/src/debug/Log.hpp>
 
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/Window.hpp>
+#include <hyprland/src/desktop/Window.hpp>
 #include <hyprland/src/managers/AnimationManager.hpp>
 
 #include "Flash.hpp"


### PR DESCRIPTION
Hyprland moved the file `src/Window.hpp` to `src/desktop/Window.hpp` ([hyprwm/Hyprland@8593c45](https://github.com/hyprwm/Hyprland/commit/8593c45be3cfe8055d13315051d88588f848ad39)). This should make the plugin compile again