### PR TITLE
Fix hyprland error `hyprfocus::* not found` in readme getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ hyprpm add https://github.com/pyt0xic/hyprfocus
 to start using hyprfocus, add this to your hyprland config:
 
 ```
-    hyprfocus {
+    plugin:hyprfocus {
         enabled = yes
         animate_floating = yes
         animate_workspacechange = yes


### PR DESCRIPTION
Hey,
Thank you for fixing this plugin.
When i tried to use it in hyprland-git as of 14-4-2024 i got an error saying some hyprfocus: fields are not known. Problem was missing plugin: before hyprfocus config.